### PR TITLE
Use OpenZeppelin's ReentrancyGuard and add events

### DIFF
--- a/contracts/HTLC.sol
+++ b/contracts/HTLC.sol
@@ -1,9 +1,11 @@
 pragma solidity ^0.4.0;
 
+import 'zeppelin-solidity/contracts/ReentrancyGuard.sol';
+
 /**
  * @title Hashed time-locked contract.
  */
-contract HTLC {
+contract HTLC is ReentrancyGuard {
     enum State {
         INITIATED,
         COMPLETED,
@@ -24,15 +26,6 @@ contract HTLC {
     // State of the exchange
     State state;
 
-    bool locked;
-    modifier noReentrancy() {
-      require(!locked);
-      locked = true;
-      _;
-      locked = false;
-    }
-
-
     function HTLC (address _recipient, bytes32 _image, uint _expirationTime) payable {
         sender = msg.sender;
         recipient = _recipient;
@@ -41,7 +34,7 @@ contract HTLC {
         state = State.INITIATED;
     }
 
-    function complete (bytes _preimage) public noReentrancy {
+    function complete (bytes _preimage) public nonReentrant {
         require(hash(_preimage) == image);
         require(msg.sender == recipient);
         require(state == State.INITIATED);
@@ -54,7 +47,7 @@ contract HTLC {
         }
     }
 
-    function reclaim (bytes _preimage) public noReentrancy {
+    function reclaim (bytes _preimage) public nonReentrant {
         require(hash(_preimage) == image);
         require(msg.sender == sender);
         require(

--- a/contracts/HTLC.sol
+++ b/contracts/HTLC.sol
@@ -27,10 +27,10 @@ contract HTLC is ReentrancyGuard {
     State state;
 
     // Events
-    event Initiated(address from, address to, uint amount, uint expirationTimestamp);
-    event Completed(address from, address to, uint amount);
-    event Expired(address from, address to, uint amount);
-    event Reclaimed(address from, uint amount);
+    event Initiated(address _sender, address _recipient, uint _amount, uint _expires);
+    event Completed(address _sender, address _recipient, uint _amount);
+    event Expired(address _sender, address _recipient, uint _amount);
+    event Reclaimed(address _sender, uint _amount);
 
     function HTLC (address _recipient, bytes32 _image, uint _expirationTime) payable {
         // Define internal state

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "truffle test"
+  },
   "dependencies": {
     "bignumber": "^1.1.0",
     "ethereumjs-testrpc": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "sha.js": "^2.4.9",
     "solc": "^0.4.17",
     "truffle": "^3.4.11",
-    "web3": "1.0.0-beta.20"
+    "web3": "1.0.0-beta.20",
+    "zeppelin-solidity": "^1.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,6 +2176,10 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
+pad@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pad/-/pad-1.1.0.tgz#7a7d185200ebac32f9f12ee756c3a1d087b3190b"
+
 pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3159,3 +3159,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+zeppelin-solidity@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/zeppelin-solidity/-/zeppelin-solidity-1.3.0.tgz#066ab35d7e07510da391d1dbaaf319e0d06fcfc6"


### PR DESCRIPTION
This PR addresses #2 and improves #3 by using a community-audited and -tested contract for guarding against reentrancy (`ReentrancyGuard` from [OpenZeppelin](https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/ReentrancyGuard.sol)) so we don't need to roll our own logic.