### PR TITLE
Change preimage to bytes32

### DIFF
--- a/contracts/HTLC.sol
+++ b/contracts/HTLC.sol
@@ -41,7 +41,12 @@ contract HTLC {
         state = State.INITIATED;
     }
 
-    function complete (bytes _preimage) public noReentrancy {
+    /**
+     *  Called by the recipient once they've obtained the primage from the sender.
+     *  This allows them to receive their ETH and complete the transaction.
+     *  @param _preimage - The secret that when hashed will produce the original image
+     */
+    function complete (bytes32 _preimage) public noReentrancy {
         require(hash(_preimage) == image);
         require(msg.sender == recipient);
         require(state == State.INITIATED);
@@ -54,7 +59,13 @@ contract HTLC {
         }
     }
 
-    function reclaim (bytes _preimage) public noReentrancy {
+    /**
+     *  Called by the sender after the expiration time has elapsed. If the recipient
+     *  was not able to complete the transaction in time and the sender can prove
+     *  they have the secret they're able to reclaim their funds.
+     *  @param _preimage - The secret that when hashed will produce the original image
+     */
+    function reclaim (bytes32 _preimage) public noReentrancy {
         require(hash(_preimage) == image);
         require(msg.sender == sender);
         require(
@@ -75,7 +86,13 @@ contract HTLC {
         }
     }
 
-    function hash (bytes _preimage) internal returns (bytes32 _image) {
-      return sha256(_preimage);
+    /**
+     *  The hash function for producing the image from the preimage. Right now
+     *  this is using SHA256 but it should be updated to use SHA256d.
+     *  @param _preimage - The value to hash
+     *  @return The hashed image
+     */
+    function hash (bytes32 _preimage) internal returns (bytes32 _image) {
+        return sha256(_preimage);
     }
 }

--- a/test/htlc.js
+++ b/test/htlc.js
@@ -2,12 +2,24 @@ const shajs = require('sha.js')
 const pad = require('pad')
 
 const HTLC = artifacts.require('./HTLC.sol')
+
 /**
  * Utilities
  */
 
 const etherToWei = value => web3.toWei(value, 'ether')
 const weiToEther = value => web3.fromWei(value, 'ether')
+
+// 0-pads a string to 64 characters (32 bytes)
+const to32No0x = buffer => pad(buffer, 64, '0')
+// 0-pads a string into 64 characters (32 bytes) and prepends a 0x
+const to32 = buffer => `0x${to32No0x(buffer)}`
+// Converts an ascii string into a hex string
+const encodeString = str => Buffer.from(str).toString('hex')
+// Converts a hex string into an ascii string
+const decodeString = hex => new Buffer(to32No0x(hex), 'hex').toString()
+
+const delay = t => new Promise(resolve => setTimeout(resolve, t))
 
 const transactionCost = tx =>
   web3.eth.getTransactionReceipt(tx).gasUsed * web3.eth.getTransaction(tx).gasPrice
@@ -72,22 +84,17 @@ contract('HTLC', async accounts => {
     )
   })
 
-  function to32(buffer) {
-    return `0x${pad(buffer, 64, '0')}`
-  }
-
-  function delay(t) {
-    return new Promise(function(resolve) {
-      setTimeout(resolve, t)
-    })
-  }
-
   it('balances are correct after exchange is completed', async () => {
     const sender = accounts[0]
     const recipient = accounts[1]
     const secret = 'secret'
 
-    const image = to32(hash(secret))
+    /**
+     * This decode(encode(x)) is absolute magic. I can't explain why this is necessary but it's the only way
+     * I've found to get the images to match between JS and the EVM when using a 32-byte
+     * preimage.
+     */
+    const image = to32(hash(decodeString(encodeString(secret))))
 
     const senderBalanceBefore = web3.eth.getBalance(sender)
     const recipientBalanceBefore = web3.eth.getBalance(recipient)
@@ -100,6 +107,7 @@ contract('HTLC', async accounts => {
     })
 
     // Complete the exchange and send the 2 ETH to the recipient
+
     const completion = await instance.complete(secret, { from: recipient })
 
     // Verify that the contract balance is back to 0
@@ -131,8 +139,7 @@ contract('HTLC', async accounts => {
     const sender = accounts[0]
     const recipient = accounts[1]
     const secret = 'secret'
-
-    const image = to32(hash(secret))
+    const image = to32(hash(decodeString(encodeString(secret))))
 
     const senderBalanceBefore = web3.eth.getBalance(sender)
     const recipientBalanceBefore = web3.eth.getBalance(recipient)
@@ -166,7 +173,7 @@ contract('HTLC', async accounts => {
     const recipient = accounts[1]
     const secret = 'secret'
 
-    const image = to32(hash(secret))
+    const image = to32(hash(decodeString(encodeString(secret))))
 
     // Create a HTLC contract to send 2 ETH from sender to recipient
     // if the recipient can provide the secret within 10 seconds


### PR DESCRIPTION
This is a prerequisite for https://github.com/functionalfoundry/ethereum-htlc/issues/1. Initially I tried just changing the hash on the JS side and EVM side but the images no longer matched.

In Solidity, SHA256 returns a bytes32 so if it's going to do 2 rounds, it really needs to take the same type for both rounds in order to return a predictable result.

This ended up being more challenging than expected.
An ascii string looks like `secret`
A hex string looks like `736563726574`
A bytes32 string looks like `0x7365637265740000000000000000000000000000000000000000000000000000`

Our node SHA256 function accepts an ascii string. The EVM SHA256 accepts a hex string. An image of an ascii string in node matches an image of the corresponding hex string on the EVM. However, switching to byte32 breaks this. In order to make it work I needed to encode the ascii string into a 32 byte hex string, then decode it back to ascii, and then hash it. Even logging the original and transformed ascii strings makes them appear identical. Apparently going through this exercise does change the string's value though and this is the only way to get the hash in JS is to match the hash on the EVM.